### PR TITLE
Signature name

### DIFF
--- a/templates/padm2/partials/base.hbs
+++ b/templates/padm2/partials/base.hbs
@@ -77,13 +77,6 @@
     </tr>
 
     <tr>
-        <th>Signerende lege</th>
-    </tr>
-    <tr>
-        <td class="cellBottom">Må sendes fra Padm2</td>
-    </tr>
-
-    <tr>
         <th>Sendt</th>
     </tr>
     <tr>

--- a/templates/padm2/partials/base.hbs
+++ b/templates/padm2/partials/base.hbs
@@ -70,17 +70,17 @@
     </tr>
 
     <tr>
-        <th>Dokumentreferanse</th>
-    </tr>
-    <tr>
-        {{> padm2/partials/dokumentreferanse }}
-    </tr>
-
-    <tr>
-        <th>Fra</th>
+        <th>Fra behandlende lege</th>
     </tr>
     <tr>
         <td class="cellBottom">{{ dialogmelding.navnHelsepersonell }}</td>
+    </tr>
+
+    <tr>
+        <th>Signerende lege</th>
+    </tr>
+    <tr>
+        <td class="cellBottom">Må sendes fra Padm2</td>
     </tr>
 
     <tr>
@@ -91,11 +91,12 @@
     </tr>
 
     <tr>
-        <th>Signatur navn</th>
+        <th>Dokumentreferanse</th>
     </tr>
     <tr>
-        <td>Må sendes fra Padm2</td>
+        {{> padm2/partials/dokumentreferanse }}
     </tr>
+
 </table>
 
 {{> padm2/partials/innkallingmoterespons }}

--- a/templates/padm2/partials/dokumentreferanse.hbs
+++ b/templates/padm2/partials/dokumentreferanse.hbs
@@ -1,4 +1,4 @@
-<td class="cellBottom">
+<td>
     {{#if dialogmelding.innkallingMoterespons }}
         {{ dialogmelding.innkallingMoterespons.dokIdNotat }}
     {{/if}}


### PR DESCRIPTION
Remove signature name, i.e the name of the signing doctor, until we have that information from Padm2. We need to fetch the name from HPR in Padm2 first, and we don't have an endpoint for it yet. The only doctor that will use our pdf is our test prod doctor. 