### PR TITLE
Fix html syntax error in partial Avvist

### DIFF
--- a/templates/padm2/partials/avvist.hbs
+++ b/templates/padm2/partials/avvist.hbs
@@ -1,14 +1,15 @@
 {{#eq validationResult.status "INVALID" }}
     <h3>Begrunnelse for avvisning</h3>
     <table>
-        <tr>
-            <td>
-                <ul>{{#each validationResult.ruleHits}}
-                    <li>{{messageForSender}}</li>
-                {{/each}}
-                </ul>
-            </td>
-        </tr>
+        <tbody>
+            <tr>
+                <td>
+                    <ul>{{#each validationResult.ruleHits}}
+                        <li>{{messageForSender}}</li>
+                    {{/each}}
+                    </ul>
+                </td>
+            </tr>
         </tbody>
     </table>
 {{/eq}}


### PR DESCRIPTION
Start of html tbody-tag is missing and is causing an exception for Avvist.