### PR TITLE
Breaklines tekst notat innhold

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/pdfgen:f3fda1f27664f189e9cd3b44223da4867189947b
+FROM navikt/pdfgen:096d823096fb366a6a90dfeae4401d165dd7bbb6
 
 COPY templates /app/templates
 COPY fonts /app/fonts

--- a/data/padm2/padm2.json
+++ b/data/padm2/padm2.json
@@ -42,7 +42,7 @@
         "arenaNotatKode": "",
         "arenaNotatTittel": ""
       },
-      "tekstNotatInnhold": "Pasienten har masse info her",
+      "tekstNotatInnhold": "Pasienten har masse info her\n  -Vedlegg 1: Epikrise\n  -Vedlegg 2: Røntgen-bilde\n -Vedlegg 3: Støvsugermanual",
       "dokIdNotat": "",
       "datoNotat": "2020-05-19T08:24:07.139419"
     },
@@ -55,7 +55,7 @@
         "arenaNotatKode": "32",
         "arenaNotatTittel": "Henvendelse fra lege"
       },
-      "tekstNotatInnhold": "Jeg er klar 12.30. Mvh, Lege legsesn",
+      "tekstNotatInnhold": "Jeg er klar 12.30.\n Mvh, Lege legsesn",
       "dokIdNotat": "",
       "foresporsel": {
         "typeForesp": {

--- a/run_development.sh
+++ b/run_development.sh
@@ -2,7 +2,7 @@
 
 CURRENT_PATH="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 
-docker pull navikt/pdfgen
+docker pull navikt/pdfgen:096d823096fb366a6a90dfeae4401d165dd7bbb6
 docker run \
         -v $CURRENT_PATH/templates:/app/templates \
         -v $CURRENT_PATH/fonts:/app/fonts \

--- a/run_development_windows.sh
+++ b/run_development_windows.sh
@@ -2,7 +2,7 @@
 
 CURRENT_PATH=$(pwd)
 
-winpty docker pull navikt/pdfgen
+winpty docker pull navikt/pdfgen:096d823096fb366a6a90dfeae4401d165dd7bbb6
 winpty docker run \
         -v "/$CURRENT_PATH/templates:/app/templates" \
         -v "/$CURRENT_PATH/fonts:/app/fonts" \

--- a/templates/padm2/partials/foresporselsvar.hbs
+++ b/templates/padm2/partials/foresporselsvar.hbs
@@ -26,7 +26,7 @@
             <th>Notat/Svar</th>
         </tr>
         <tr>
-            <td>{{ dialogmelding.foresporselFraSaksbehandlerForesporselSvar.tekstNotatInnhold }}</td>
+            <td>{{ breaklines dialogmelding.foresporselFraSaksbehandlerForesporselSvar.tekstNotatInnhold }}</td>
         </tr>
 
     </table>

--- a/templates/padm2/partials/henvendelsefralege.hbs
+++ b/templates/padm2/partials/henvendelsefralege.hbs
@@ -28,7 +28,7 @@
             <th>Notat</th>
         </tr>
         <tr>
-            <td>{{ dialogmelding.henvendelseFraLegeHenvendelse.tekstNotatInnhold }}</td>
+            <td>{{ breaklines dialogmelding.henvendelseFraLegeHenvendelse.tekstNotatInnhold }}</td>
         </tr>
 
     </table>

--- a/templates/padm2/partials/innkallingmoterespons.hbs
+++ b/templates/padm2/partials/innkallingmoterespons.hbs
@@ -26,7 +26,7 @@
             <th>Notat</th>
         </tr>
         <tr>
-            <td>{{ dialogmelding.innkallingMoterespons.tekstNotatInnhold }}</td>
+            <td>{{ breaklines dialogmelding.innkallingMoterespons.tekstNotatInnhold }}</td>
         </tr>
 
     </table>


### PR DESCRIPTION
Oppgrader til nyeste versjon av `pdfgen`, siden den versjonen vi brukte ikke har `breaklines`-hjelpemetode.

Det trengs mer testing for å finne ut om den klarer å gjenskape formattering på ekte dialogmeldinger, men da må vi fikse syfomock-backend først. Den klarer i hvert fall å lage new lines hvis man sender inn `\n` eller `\r\n` i syfomock.

Ting ser ut til å fungere fint i preprod, så jeg tror ikke den nye versjonen av pdfgen har ødelagt noe.

Jeg tenker vi kan dytte ut dette, og så kan noen sjekke om dialogmeldinger får bedre formattering i prod.